### PR TITLE
add Linux ARM 64 support #3

### DIFF
--- a/ext/cmdstan/extconf.rb
+++ b/ext/cmdstan/extconf.rb
@@ -1,11 +1,17 @@
 require "digest"
 require "fileutils"
 require "net/http"
+require "rbconfig"
 require "tmpdir"
 
 version = "2.28.1"
-checksum = "eacadb4a1ca6997c9858e301780e729e53a9b5207b19ae2616abc882677e7637"
-url = "https://github.com/stan-dev/cmdstan/releases/download/v#{version}/cmdstan-#{version}.tar.gz"
+if RbConfig::CONFIG['host_cpu'] == "aarch64"
+  checksum = "0ab11724e51df1744e36a8ff29275ee04d14098ee18c0ed9227ee606d30181d9"
+  url =  "https://github.com/stan-dev/cmdstan/releases/download/v#{version}/cmdstan-#{version}-linux-arm64.tar.gz"
+else
+  checksum = "eacadb4a1ca6997c9858e301780e729e53a9b5207b19ae2616abc882677e7637"
+  url = "https://github.com/stan-dev/cmdstan/releases/download/v#{version}/cmdstan-#{version}.tar.gz"
+end
 
 path = ENV["CMDSTAN"] || File.expand_path("../../tmp/cmdstan", __dir__)
 FileUtils.mkdir_p(path)


### PR DESCRIPTION
Hello,

I test the code on my arm64 linux and it works.

```
(venv) nabil@dev-server:~/cmdstan-ruby$ bundle exec rake test
Run options: --seed 38252

# Running:

.

Fabulous run in 8.282269s, 0.1207 runs/s, 1.2074 assertions/s.

1 runs, 10 assertions, 0 failures, 0 errors, 0 skips
```